### PR TITLE
Added missing 'break' in fetch method switch statement

### DIFF
--- a/mysqlresultset.php
+++ b/mysqlresultset.php
@@ -136,6 +136,7 @@ class MySqlResultSet implements Iterator
                     break;
                 case MySqlResultSet::DATA_ARRAY: 
                     $func = 'mysql_fetch_array';
+                    break;
                 default: 
                     $func = 'mysql_fetch_object';
                     break;


### PR DESCRIPTION
case MySqlResultSet::DATA_ARRAY: will currently always fall through to the default case
